### PR TITLE
#1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY checkstyle-suppressions.xml /
 COPY pom.xml /
 RUN mvn -f /pom.xml clean package
 
-FROM openjdk:17-jdk-slim
+FROM openjdk:17-ea-3-jdk-slim
 WORKDIR /
 COPY /src /src
 COPY --from=build /target/*jar application.jar


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `Dockerfile` to change the base image from `openjdk:17-jdk-slim` to `openjdk:17-ea-3-jdk-slim`, indicating a shift to an early access version of OpenJDK.

### Detailed summary
- Updated the base image from `openjdk:17-jdk-slim` to `openjdk:17-ea-3-jdk-slim`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->